### PR TITLE
Fix accidental bad format for ftSlotManager global.

### DIFF
--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -8,7 +8,7 @@
 27,6,58D8: g_stTriggerMng
 805a00e0:g_GameGlobal
 27,6,2E68: g_ftManager
-27,6,2E90, g_ftSlotManager
+27,6,2E90: g_ftSlotManager
 27,6,2EB4: g_ftInstanceManager
 27,6,2E70: g_ftAudienceManager
 27,6,5518: g_aiMgr


### PR DESCRIPTION
Not much to say here, there's a comma instead of a colon.