### PR TITLE
Upstream project punch porting work changes

### DIFF
--- a/Brawl/Include/ft/ft_manager.h
+++ b/Brawl/Include/ft/ft_manager.h
@@ -117,6 +117,8 @@ public:
     int getTeam(int entryId, bool unk2, bool unk3);
     Vec3f getFighterCenterPos(int entryId, int unk);
     float getFighterLr(int entryId, int unk);
+    int getFighterOperationType(int entryId);
+    int getFighterOperationStatus(int entryId);
     Fighter* searchNearFighter(float unk1, float radius, Vec3f* pos, int team, bool unk4);
     void setHeal(int entryId, float heal);
     void setCurry(int entryId);
@@ -127,6 +129,7 @@ public:
     void setInfiniteScaling(int entryId, int unk1, int unk2);
     void setThunder(int inflictingEntryId, int unk2);
     void setWarpFighter(int entryId, Vec3f* pos, float lr, bool showEffect);
+    void setFighterOperationStatus(int entryId, int fighterOperationStatus);
 
     void pickupCoin(int entryId, int amount);
     void setDead(int entryId, int unk1, int unk2);

--- a/Brawl/Include/ms/ms_char_writer.h
+++ b/Brawl/Include/ms/ms_char_writer.h
@@ -1,22 +1,22 @@
 #pragma once
 
-#include <GX.h>
 #include <StaticAssert.h>
 #include <types.h>
+#include <nw4r/ut/color.h>
 
 namespace ms {
     class CharWriter {
     public:
         // These get set by SetColorMapping
-        GXColor m_colorMapping1;  // 0
-        GXColor m_colorMapping2;  // 4
+        nw4r::ut::Color m_colorMapping1;  // 0
+        nw4r::ut::Color m_colorMapping2;  // 4
         struct {
-            GXColor m_topLeft;     // 8
-            GXColor m_topRight;    // 12, 0xC
-            GXColor m_bottomLeft;  // 16, 0x10
-            GXColor m_bottomRight; // 20, 0x14
+            nw4r::ut::Color m_topLeft;     // 8
+            nw4r::ut::Color m_topRight;    // 12, 0xC
+            nw4r::ut::Color m_bottomLeft;  // 16, 0x10
+            nw4r::ut::Color m_bottomRight; // 20, 0x14
         } m_colorRect;
-        GXColor m_textColor; // 24, 0x18
+        nw4r::ut::Color m_textColor; // 24, 0x18
         int m_28; // Always 0xFFFFFFFF?, 0x1C
         char m_32[4]; // 0x20
         float m_fontScaleX; // 36, 0x24
@@ -45,7 +45,7 @@ namespace ms {
         // offset 92
         float m_edgeWidth; // Text outline in units / 6
         // offset 96
-        GXColor m_edgeColor;
+        nw4r::ut::Color m_edgeColor;
         // offset 100
         int m_100;
         float m_104;
@@ -53,7 +53,7 @@ namespace ms {
         char _109[3];
 
         CharWriter();
-        virtual ~CharWriter();
+        ~CharWriter();
 
         /* Setters */
         void SetCursor(float x, float y); // 
@@ -63,10 +63,10 @@ namespace ms {
         void SetCursorZ(float z);
         void SetScale(float x, float y);
         void SetScale(float scale);
-        void SetEdge(float width, GXColor color); // 8006ab20
+        void SetEdge(float width, nw4r::ut::Color color); // 8006ab20
         // Not sure what this does yet.
-        void SetColorMapping(GXColor a, GXColor b);
-        void SetTextColor(GXColor textColor);
+        void SetColorMapping(nw4r::ut::Color a, nw4r::ut::Color b);
+        void SetTextColor(nw4r::ut::Color textColor);
         void setAlpha(unsigned char alpha);
         void SetFixedWidth(float fixedWidth);
         void EnableFixedWidth(bool enabled);
@@ -90,7 +90,7 @@ namespace ms {
         /* GFX Stuff */
         void SetupGX(); 
         // Called by SetupGX(), presumably with the values in the charwriter already.
-        void SetupGXWithColorMapping(GXColor color1, GXColor color2);
+        void SetupGXWithColorMapping(nw4r::ut::Color color1, nw4r::ut::Color color2);
 
         /* The magic function. */
         void Print(u16 character);
@@ -101,6 +101,5 @@ namespace ms {
         // sets up its args and calls it.
         void PrintGlyph(double x, double y, double z, const void* glyphTexture); // 0x8007001c
     };
-    // Originally 0x70, virtual dtor made it bigger?
-    static_assert(sizeof(CharWriter) == 0x74, "Class is the wrong size!");
+    static_assert(sizeof(CharWriter) == 0x70, "Class is the wrong size!");
 }

--- a/Brawl/Include/so/motion/so_motion_module_impl.h
+++ b/Brawl/Include/so/motion/so_motion_module_impl.h
@@ -137,6 +137,7 @@ public:
 static_assert(sizeof(soMotionModule) == 4, "Class is wrong size!");
 
 class soMotionModuleImpl : public soMotionModule, public soStatusEventObserver, public soAnimCmdEventObserver, public soModelEventObserver, public soEventPresenter<soMotionEventObserver> {
+public:
 
     // 52
     char _spacer1[4];
@@ -186,7 +187,6 @@ class soMotionModuleImpl : public soMotionModule, public soStatusEventObserver, 
     // 364
     char _spacer5[4];
 
-public:
     // TODO: verify params
     virtual ~soMotionModuleImpl();
     virtual void activate();

--- a/Brawl/Include/so/work/so_work_manage_module_impl.h
+++ b/Brawl/Include/so/work/so_work_manage_module_impl.h
@@ -4,6 +4,7 @@
 #include <so/so_lock.h>
 #include <so/so_null.h>
 #include <so/work/so_general_work_simple.h>
+#include <so/event/so_event_observer.h>
 #include <types.h>
 
 class soWorkManageModule : public soNullable {

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -86,6 +86,7 @@ CC008000:WGPIPE
 801d76e8:DCFlushRange
 801d77cc:ICInvalidateRange
 803f0f44:__dynamic_cast
+803f0e38:__ptmf_scall
 
 // OS
 801d8600:OSReport
@@ -104,6 +105,7 @@ CC008000:WGPIPE
 803fa280:strcpy__FPcPCc
 803fa280:strcpy
 803f89fc:sprintf
+803f8924:snprintf
 803fa384:strcat__FPcPc
 803fa3b0:strncat__FPcPc
 803fa3b0:strncat
@@ -895,6 +897,8 @@ CC008000:WGPIPE
 27,1,00109E14:setWarpFighter__9ftManagerFiP5Vec3ffb
 27,1,0010ADE8:getFighterCenterPos__9ftManagerFii
 27,1,0010AF34:getFighterLr__9ftManagerFii
+27,1,0010a164:getFighterOperationStatus__9ftManagerFi
+27,1,0010a248:getFighterOperationType__9ftManagerFi
 
 // Fighter
 27,1,00138900:setCurry__7FighterFbi

--- a/nw4r/include/nw4r/ut/color.h
+++ b/nw4r/include/nw4r/ut/color.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <StaticAssert.h>
+#include <types.h>
+
+namespace nw4r {
+    namespace ut {
+        struct Color {
+            u8 m_r;
+            u8 m_g;
+            u8 m_b;
+            u8 m_a;
+        };
+        static_assert(sizeof(Color) == 0x4, "Class is the wrong size!");
+    }
+}


### PR DESCRIPTION
I know you rolled back the nw4r::ut::Color stuff last time; I completely forgot to include that file in my previous PR. The class is a type pun with GXColor so it'll work regardless, but all the symbols in `RSBE01.lst` and in dolphin refer to the nw4r class, so I thought it was worth keeping it consistent. If you want to just use GXColor in this repo, that's fine and I'll update the linking symbols and remove the change from this PR.

The other stuff is the fighter operation functions in ft_manager, which I use to determine if a player is a CPU (type) and whether the games has started (there is a frozen status during the countdown). I also mapped 1 or 2 mwcc library functions that were previously unmapped.