### PR TITLE
soAnimCmdModuleImpl and soColorBlendModuleImpl

### DIFF
--- a/Brawl/Include/ac/ac_anim_cmd_impl.h
+++ b/Brawl/Include/ac/ac_anim_cmd_impl.h
@@ -2,12 +2,20 @@
 
 #include <StaticAssert.h>
 #include <so/so_null.h>
+#include <so/anim_cmd/so_anim_cmd.h>
 #include <types.h>
 
-class acAnimCmd : public soNullable {
-    // TODO
+// TODO: Verify this.
+class acAnimCmd: soNullable {
+public:
+    virtual int getGroup() = 0;
 };
 
 class acAnimCmdImpl : public acAnimCmd {
+public:
     // TODO
+    virtual int getGroup();
+
+    soAnimCmd* m_latestWaitCmd;
 };
+static_assert(sizeof(acAnimCmdImpl) == 0xC, "Class is the wrong size!");

--- a/Brawl/Include/ac/ac_anim_cmd_impl.h
+++ b/Brawl/Include/ac/ac_anim_cmd_impl.h
@@ -5,9 +5,12 @@
 #include <so/anim_cmd/so_anim_cmd.h>
 #include <types.h>
 
-// TODO: Verify this.
+// TODO: Verify and add virtual functions.
 class acAnimCmd: soNullable {
 public:
+    // There are more methods than just this one,
+    // but I only defined one to force it to be considered
+    // a virtual class with a vtable of its own.
     virtual int getGroup() = 0;
 };
 

--- a/Brawl/Include/ms/ms_char_writer.h
+++ b/Brawl/Include/ms/ms_char_writer.h
@@ -17,8 +17,9 @@ namespace ms {
             nw4r::ut::Color m_bottomRight; // 20, 0x14
         } m_colorRect;
         nw4r::ut::Color m_textColor; // 24, 0x18
-        int m_28; // Always 0xFFFFFFFF?, 0x1C
-        char m_32[4]; // 0x20
+        nw4r::ut::Color m_unkColor;  // 28, 0x1C some other color, used by setAlpha if offset 0x20 is 1
+        char m_32;    // 0x20, flag used in setAlpha?
+        char m_33[3]; // 0x21 // seems to be an int enum?
         float m_fontScaleX; // 36, 0x24
         float m_fontScaleY; // 40, 0x28
         float m_xPos; // 44, 0x2C
@@ -26,7 +27,8 @@ namespace ms {
         float m_zPos; // 52, 0x34
         int m_56; // Always = 1?, 0x38
         int m_60; // Always = 1?, 0x3C
-        char _64[3]; // Always 0xCCCCFF?, 0x40
+        char _64[2]; // Always 0xCCCC? Might be padding.
+        u8 m_alpha; // 66, 0x42
         // offset 67
         bool m_isFixedWidth;
         // offset 68
@@ -36,20 +38,19 @@ namespace ms {
         // The melee font which is always loaded seems to be at 0x80497e44
         // offset 72
         void* m_font;
-        char _76[4];
+        char _76[4]; // 0x4C, set to 0 in constructor
         // offset 80
-        float m_scale; // World scaler, so it affects positioning too. Usually 1.
-        char _84[4];
-        // offset 88
-        float m_unknownFontWidthModifier; // Usually close to 1, seems to affect width.
-        // offset 92
-        float m_edgeWidth; // Text outline in units / 6
-        // offset 96
-        nw4r::ut::Color m_edgeColor;
+        float m_scale; // 80, 0x50 World scaler, so it affects positioning too. Set to 1 in ctor.
+        u8 _84;  // 84, 0x54 // unk flag, set to 0
+        u8 _85;  // 85, 0x55 // unk flag, set to 0
+        char _86[2];  // 86, 0x56 Looks like padding?
+        float m_unknownFontWidthModifier; // 88, 0x58   Usually close to 1, seems to affect width. Set to 1 in ctor
+        float m_edgeWidth; // 92, 0x5C Text outline in units / 6, set to 0 in ctor
+        nw4r::ut::Color m_edgeColor; // 96, 0x60, set to 0xFF in the constructor, aka black.
         // offset 100
-        int m_100;
-        float m_104;
-        u8 m_108;
+        int m_100; // 100, 0x64, set to 1 in ctor
+        float m_104; // 104, 0x68, set to 1.0 in ctor
+        u8 m_108; // 108, 0x6C, set to 0 in ctor
         char _109[3];
 
         CharWriter();
@@ -67,7 +68,7 @@ namespace ms {
         // Not sure what this does yet.
         void SetColorMapping(nw4r::ut::Color a, nw4r::ut::Color b);
         void SetTextColor(nw4r::ut::Color textColor);
-        void setAlpha(unsigned char alpha);
+        void SetAlpha(unsigned char alpha); // Doesn't affect edge color it seems.
         void SetFixedWidth(float fixedWidth);
         void EnableFixedWidth(bool enabled);
 

--- a/Brawl/Include/ms/ms_char_writer.h
+++ b/Brawl/Include/ms/ms_char_writer.h
@@ -18,8 +18,10 @@ namespace ms {
         } m_colorRect;
         nw4r::ut::Color m_textColor; // 24, 0x18
         nw4r::ut::Color m_unkColor;  // 28, 0x1C some other color, used by setAlpha if offset 0x20 is 1
-        char m_32;    // 0x20, flag used in setAlpha?
-        char m_33[3]; // 0x21 // seems to be an int enum?
+        // 0x20, flag used in setalpha
+        // seems to toggle between m_textColor(0) and m_unkColor(1) for the active color.
+        char m_32;
+        char m_33[3]; // 0x21, unknown, might be padding or other flags. 
         float m_fontScaleX; // 36, 0x24
         float m_fontScaleY; // 40, 0x28
         float m_xPos; // 44, 0x2C
@@ -64,11 +66,23 @@ namespace ms {
         void SetCursorZ(float z);
         void SetScale(float x, float y);
         void SetScale(float scale);
+        // Text outline color.
         void SetEdge(float width, nw4r::ut::Color color); // 8006ab20
         // Not sure what this does yet.
         void SetColorMapping(nw4r::ut::Color a, nw4r::ut::Color b);
         void SetTextColor(nw4r::ut::Color textColor);
-        void SetAlpha(unsigned char alpha); // Doesn't affect edge color it seems.
+        /*
+         * I reverse engineered SetAlpha a little bit. The way that it works
+         * seems to be that it takes the m_alpha field and the active textColor field
+         * (either m_textColor or m_unknownColor based on whether). It applies the alpha
+         * to the alpha of the base color and assigns that to all four corners of the color
+         * rect structure to form a solid color. This function doesn't seem to affect the
+         * outline color at all, and practically speaking this means that it stays solid
+         * as transparency drops, so with a black outline the text goes black instead of
+         * transparent. This is avoidable by manually setting the edge color to the appropriate
+         * alpha value.
+         */
+        void SetAlpha(unsigned char alpha);
         void SetFixedWidth(float fixedWidth);
         void EnableFixedWidth(bool enabled);
 

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd.h
@@ -16,13 +16,13 @@ class soAnimCmd;
 #define ANIM_CMD_VAR_TYPE_RA 2
 
 enum soAnimCmdArgumentType {
-    ANIM_CMD_ARG_INT = 0,
-    ANIM_CMD_ARG_SCALAR = 1,
-    ANIM_CMD_ARG_PTR = 2,
-    ANIM_CMD_ARG_BOOL = 3,
-    ANIM_CMD_ARG_FILE = 4,
-    ANIM_CMD_ARG_VARIABLE = 5,
-    ANIM_CMD_ARG_REQUIREMENT = 6
+    AnimCmd_Arg_Type_Int = 0,
+    AnimCmd_Arg_Type_Scalar = 1,
+    AnimCmd_Arg_Type_Ptr = 2,
+    AnimCmd_Arg_Type_Bool = 3,
+    AnimCmd_Arg_Type_File = 4,
+    AnimCmd_Arg_Type_Variable = 5,
+    AnimCmd_Arg_Type_Requirement = 6
 };
 
 class soAnimCmdArgument {

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <StaticAssert.h>
+
+class soAnimCmdArgument;
+class soAnimCmd;
+
+// Variable Data Type
+#define ANIM_CMD_INT 0
+#define ANIM_CMD_FLOAT 1
+#define ANIM_CMD_BOOL 2 
+
+// Variable Memory Type
+#define ANIM_CMD_VAR_TYPE_IC 0
+#define ANIM_CMD_VAR_TYPE_LA 1
+#define ANIM_CMD_VAR_TYPE_RA 2
+
+enum soAnimCmdArgumentType {
+    ANIM_CMD_ARG_INT = 0,
+    ANIM_CMD_ARG_SCALAR = 1,
+    ANIM_CMD_ARG_PTR = 2,
+    ANIM_CMD_ARG_BOOL = 3,
+    ANIM_CMD_ARG_FILE = 4,
+    ANIM_CMD_ARG_VARIABLE = 5,
+    ANIM_CMD_ARG_REQUIREMENT = 6
+};
+
+class soAnimCmdArgument {
+public:
+    soAnimCmdArgumentType m_varType;
+    u32 m_rawValue;
+};
+static_assert(sizeof(soAnimCmdArgument) == 0x8, "Class is the wrong size!");
+
+class soAnimCmd {
+public:
+    char m_module;
+    char m_code;
+    char m_argCount;
+    char m_option;
+    soAnimCmdArgument *m_args; // ptr to array
+};
+static_assert(sizeof(soAnimCmd) == 0x8, "Class is the wrong size!");

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd_event_observer.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd_event_observer.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <so/event/so_event_observer.h>
+
+class soAnimCmdEventObserver : public soEventObserver<soAnimCmdEventObserver> {
+public:
+    soAnimCmdEventObserver(short unitID) : soEventObserver<soAnimCmdEventObserver>(unitID) {};
+
+    virtual void addObserver(int param1, int param2);
+    virtual u32 isObserv(char unk1);
+    virtual bool notifyEventAnimCmd(acAnimCmd* acmd, soModuleAccesser* moduleAccesser, int unk3);
+};
+static_assert(sizeof(soAnimCmdEventObserver) == 12, "Class is wrong size!");

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
@@ -10,6 +10,12 @@
  * but the inheritance info doesn't show any other info. I can't get the layout right while
  * inheriting the presenter, so I commented it and added a spacer.
  * 
+ * There is an "acCmdInterpreter" class in the code that seems to do a lot
+ * of the same things as this class, but it doesn't seem to be the missing
+ * inherited object, as it is about 0x10 bigger than this class. It is perhaps
+ * the case that the acCmdInterpreter inherits this, but that class doesn't
+ * seem to have provided inheritance info.
+ *
  * I'm leaving it like this for now, since it is still somewhat useful/usable.
  */
 class soAnimCmdInterpreter /*: soEventPresenter<soAnimCmdEventObserver> */ {

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
@@ -5,24 +5,32 @@
 #include <so/so_instance_manager.h>
 #include <so/status/so_status_event_observer.h>
 
+/*
+ * This class is weird, it has a bunch of data before the event presenter vtable and info,
+ * but the inheritance info doesn't show any other info. I can't get the layout right while
+ * inheriting the presenter, so I commented it and added a spacer.
+ * 
+ * I'm leaving it like this for now, since it is still somewhat useful/usable.
+ */
 class soAnimCmdInterpreter /*: soEventPresenter<soAnimCmdEventObserver> */ {
 public:
-    char _inheritance_data[8]; // 0x0;
+    char _inheritance_data[8]; // 0x0; not sure what this is.
     float m_frameSpeed; // 0x8
     soAnimCmd* m_currentCmd; // 0xC
     soAnimCmd* m_startCmd; // 0x10
     char _unk0x14[8]; // 0x14
     soAnimCmd* m_lastWaitCmd; // 0x18
-    char _unk0x1C[4]; // 0x1C    
+    char _unk0x1C[4]; // 0x1C, event presenter vtable and fields are in here.
     float m_logicalFrame; // 0x20
 };
 static_assert(sizeof(soAnimCmdInterpreter) == 0x28, "Class is the wrong size!");
 
-class soAnimCmdAddressPackArraySeparate: public soNullableInterface /*,public soEventPresenter<soAnimCmdEventObserver>*/ {
+// This class is very much unfinished.
+class soAnimCmdAddressPackArraySeparate: public soNullableInterface  {
 public:
     virtual ~soAnimCmdAddressPackArraySeparate();
 
-    char _unk1[0x4]; // This would be the event presenter vtable.
+    char _unk1[0x4]; // unknown
     soAnimCmd* m_startCmd;
     char _unk2[0x14];
     void* m_returnStack;
@@ -33,8 +41,11 @@ class soAnimCmdControlUnit {
 public:
     soAnimCmdInterpreter* m_animCmdInterpreter; // 0x0
     soAnimCmdAddressPackArraySeparate* m_animCmdAddressPackArraySeparate; // 0x4
+    int m_id; // 0x8
+    short m_type; // 0xC
+    short m_unk;  // 0xE
 };
-static_assert(sizeof(soAnimCmdControlUnit) == 0x8, "Class is the wrong size!");
+static_assert(sizeof(soAnimCmdControlUnit) == 0x10, "Class is the wrong size!");
 
 // Type punning a soInstanceManagerFullPropertyVector<soAnimCmdControlUnit, 11> here.
 // The purpose is to name the elements, which are what you want out of this object
@@ -97,6 +108,7 @@ class soAnimCmdModuleImpl:
     public soAnimCmdEventObserver
 {
 public:
+    // This is a soInstanceManagerFullPropertyVector<soAnimCmdControlUnit, 11>*
     animCmdControlUnitVectorHelper* m_animCmdThreads; // 0x20
 };
 static_assert(sizeof(soAnimCmdModuleImpl) == 0x24, "Class is the wrong size!");

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
@@ -63,7 +63,7 @@ typedef struct {
             soInstanceUnitFullProperty<soAnimCmdControlUnit> m_infiniteLoop;
             soInstanceUnitFullProperty<soAnimCmdControlUnit> m_actionHidden;
         };
-        soInstanceUnitFullProperty<soAnimCmdControlUnit> asArray[11];
+        soInstanceUnitFullProperty<soAnimCmdControlUnit> m_asArray[11];
     };
 } animCmdControlUnitVectorHelper;
 

--- a/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
+++ b/Brawl/Include/so/anim_cmd/so_anim_cmd_module_impl.h
@@ -1,0 +1,104 @@
+#pragma once
+#include <so/anim_cmd/so_anim_cmd.h>
+#include <so/anim_cmd/so_anim_cmd_event_observer.h>
+#include <so/event/so_event_presenter.h>
+#include <so/so_instance_manager.h>
+#include <so/status/so_status_event_observer.h>
+
+class soAnimCmdInterpreter /*: soEventPresenter<soAnimCmdEventObserver> */ {
+public:
+    char _inheritance_data[8]; // 0x0;
+    float m_frameSpeed; // 0x8
+    soAnimCmd* m_currentCmd; // 0xC
+    soAnimCmd* m_startCmd; // 0x10
+    char _unk0x14[8]; // 0x14
+    soAnimCmd* m_lastWaitCmd; // 0x18
+    char _unk0x1C[4]; // 0x1C    
+    float m_logicalFrame; // 0x20
+};
+static_assert(sizeof(soAnimCmdInterpreter) == 0x28, "Class is the wrong size!");
+
+class soAnimCmdAddressPackArraySeparate: public soNullableInterface /*,public soEventPresenter<soAnimCmdEventObserver>*/ {
+public:
+    virtual ~soAnimCmdAddressPackArraySeparate();
+
+    char _unk1[0x4]; // This would be the event presenter vtable.
+    soAnimCmd* m_startCmd;
+    char _unk2[0x14];
+    void* m_returnStack;
+};
+static_assert(sizeof(soAnimCmdAddressPackArraySeparate) == 0x24, "Class is the wrong size!");
+
+class soAnimCmdControlUnit {
+public:
+    soAnimCmdInterpreter* m_animCmdInterpreter; // 0x0
+    soAnimCmdAddressPackArraySeparate* m_animCmdAddressPackArraySeparate; // 0x4
+};
+static_assert(sizeof(soAnimCmdControlUnit) == 0x8, "Class is the wrong size!");
+
+// Type punning a soInstanceManagerFullPropertyVector<soAnimCmdControlUnit, 11> here.
+// The purpose is to name the elements, which are what you want out of this object
+// the vast majority of the time.
+typedef struct {
+    int* m_vtable1;
+    char _unk[4];
+    int* m_vtable2;
+    int* m_vtable3;
+
+    // 0x10
+    void* m_soArrayVecVtable1;
+    void* m_soArrayVecVtable2;
+    u32 m_size; // = 11
+    union {
+        struct {
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_actionMain;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_subactionMain;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_subactionGfx;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_subactionSfx;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_subactionOther;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_altSubactionMain;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_altSubactionGfx;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_altSubactionSfx;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_altSubactionOther;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_infiniteLoop;
+            soInstanceUnitFullProperty<soAnimCmdControlUnit> m_actionHidden;
+        };
+        soInstanceUnitFullProperty<soAnimCmdControlUnit> asArray[11];
+    };
+} animCmdControlUnitVectorHelper;
+
+static_assert(sizeof(animCmdControlUnitVectorHelper) 
+    == sizeof(soInstanceManagerFullPropertyVector<soAnimCmdControlUnit, 11>), "Class is the wrong size!");
+
+class soAnimCmdModule: public soNullable {
+    virtual void registInterpreter();
+    virtual void interpretCmd();
+    virtual void interpretCmdAdjust();
+    virtual void interpretCmd1();
+    virtual void resetInterpreter1();
+    virtual void resetInterpreter2();
+    virtual void resetInterpreter3();
+    virtual void resetInterpreter4();
+    virtual void isInterpreterAnimCmd();
+    virtual void skipNextMotionGroup();
+    virtual bool isAnimCmdEnd();
+    virtual int getAnimCmdFrame();
+    virtual void getCmdAddressPack();
+    virtual void setAddressPackList();
+    virtual void getInterpreterNum();
+    virtual ~soAnimCmdModule();
+    virtual void activate();
+    virtual void deactivate();
+};
+
+class soAnimCmdModuleImpl:
+    public soAnimCmdModule,
+    public soStatusEventObserver,
+    public soAnimCmdEventObserver
+{
+public:
+    animCmdControlUnitVectorHelper* m_animCmdThreads; // 0x20
+};
+static_assert(sizeof(soAnimCmdModuleImpl) == 0x24, "Class is the wrong size!");
+
+/* TODO: soAnimCmdModuleNull */

--- a/Brawl/Include/so/color_blend/so_color_blend_module_impl.h
+++ b/Brawl/Include/so/color_blend/so_color_blend_module_impl.h
@@ -1,0 +1,96 @@
+#pragma once
+#include <so/so_null.h>
+#include <so/so_anim_chr.h>
+#include <so/event/so_event_observer.h>
+#include <GX/GXTypes.h>
+
+class soColorBlendModule: public soNullable {
+public:
+    // TODO: Fill out params for most of these.
+    virtual bool isNull() = 0;                                 // 0x8
+    virtual ~soColorBlendModule();                             // 0xc
+    virtual void activate() = 0;                               // 0x10
+    virtual void deactivate() = 0;                             // 0x14
+    virtual void update() = 0;                                 // 0x18
+    virtual void updateMaterial() = 0;                         // 0x1C
+    virtual void offAll() = 0;                                 // 0x20
+    virtual void setFlash() = 0;                               // 0x24
+    virtual void setFlashColorFrame() = 0;                     // 0x28
+    virtual void offFlash() = 0;                               // 0x2C
+    virtual void setLight() = 0;                               // 0x30
+    virtual void setLightColor() = 0;                          // 0x34
+    virtual void setLightColorFrame() = 0;                     // 0x38
+    virtual void setLightDir() = 0;                            // 0x3C
+    virtual void offLight() = 0;                               // 0x40
+    virtual void setPri() = 0;                                 // 0x44
+    virtual void setSubColor(GXColor color, char enabled) = 0; // 0x48
+    virtual char isEnableSubColor() = 0;                       // 0x4C
+    virtual GXColor getSubColor() = 0;                         // 0x50
+    virtual void getColorBlend() = 0;                          // 0x54
+    virtual void getLightSet() = 0;                            // 0x58
+};
+
+class soColorBlendModuleImpl: 
+    public soColorBlendModule, 
+    public soStatusEventObserver,
+    public soAnimCmdEventObserver,
+    public soModelEventObserver
+{
+public:
+    // char _vtables[4];
+    // 0x2C
+    char _unk[0x154 - 0x2C];
+
+    virtual bool isNull();
+    virtual ~soColorBlendModuleImpl();
+    virtual void activate();
+    virtual void deactivate();
+    virtual void update();
+    virtual void updateMaterial();
+    virtual void offAll();
+    virtual void setFlash();
+    virtual void setFlashColorFrame();
+    virtual void offFlash();
+    virtual void setLight();
+    virtual void setLightColor();
+    virtual void setLightColorFrame();
+    virtual void setLightDir();
+    virtual void offLight();
+    virtual void setPri();
+    virtual void setSubColor(GXColor color, char enabled);
+    virtual char isEnableSubColor();
+    virtual GXColor getSubColor();
+    virtual void getColorBlend();
+    virtual void getLightSet();
+
+    virtual u32 isObserv(char unk1);
+    virtual bool notifyEventAnimCmd(acAnimCmd* acmd, soModuleAccesser* moduleAccesser, int unk3);
+    virtual void notifyEventChangeStatus(int statusKind, int prevStatusKind, soStatusData* statusData, soModuleAccesser* moduleAccesser);
+    virtual void notifyEventConstructInstance(bool, soModuleAccesser* moduleAccesser);
+};
+static_assert(0x154 == sizeof(soColorBlendModuleImpl), "Class is wrong size!");
+
+class soColorBlendModuleNull: public soColorBlendModule {
+    virtual ~soColorBlendModuleNull();
+    virtual void activate();
+    virtual void deactivate();
+    virtual void update();
+    virtual void updateMaterial();
+    virtual void offAll();
+    virtual void setFlash();
+    virtual void setFlashColorFrame();
+    virtual void offFlash();
+    virtual void setLight();
+    virtual void setLightColor();
+    virtual void setLightColorFrame();
+    virtual void setLightDir();
+    virtual void offLight();
+    virtual void setPri();
+    virtual void setSubColor(GXColor color, char enabled);
+    virtual char isEnableSubColor();
+    virtual GXColor getSubColor();
+    virtual void getColorBlend();
+    virtual void getLightSet();
+
+    soColorBlendModuleNull* getNullInstance();
+};

--- a/Brawl/Include/so/event/so_event_observer.h
+++ b/Brawl/Include/so/event/so_event_observer.h
@@ -101,16 +101,6 @@ public:
 };
 static_assert(sizeof(soEventObserver<void>) == 0xC, "Class is wrong size!");
 
-class soAnimCmdEventObserver : public soEventObserver<soAnimCmdEventObserver> {
-public:
-    soAnimCmdEventObserver(short unitID) : soEventObserver<soAnimCmdEventObserver>(unitID) {};
-
-    virtual void addObserver(int param1, int param2);
-    virtual u32 isObserv(char unk1);
-    virtual bool notifyEventAnimCmd(acAnimCmd* acmd, soModuleAccesser* moduleAccesser, int unk3);
-};
-static_assert(sizeof(soAnimCmdEventObserver) == 12, "Class is wrong size!");
-
 class soLinkEventObserver : public soEventObserver<soLinkEventObserver> {
 public:
     soLinkEventObserver(short unitID) : soEventObserver<soLinkEventObserver>(unitID) {};
@@ -122,15 +112,6 @@ static_assert(sizeof(soLinkEventObserver) == 12, "Class is wrong size!");
 
 struct soStatusData {
 };
-
-class soStatusEventObserver : public soEventObserver<soStatusEventObserver> {
-public:
-    soStatusEventObserver(short unitID) : soEventObserver<soStatusEventObserver>(unitID) {};
-
-    virtual void addObserver(int param1, int param2);
-    virtual void notifyEventChangeStatus(int statusKind, int prevStatusKind, soStatusData* statusData, soModuleAccesser* moduleAccesser);
-};
-static_assert(sizeof(soStatusEventObserver) == 12, "Class is wrong size!");
 
 class soSituationEventObserver : public soEventObserver<soSituationEventObserver> {
 public:

--- a/Brawl/Include/so/so_instance_manager.h
+++ b/Brawl/Include/so/so_instance_manager.h
@@ -70,7 +70,7 @@ public:
 };
 
 template <class T>
-class soInstanceManagerFullProperty : public soInstanceManager<T>, public soInstanceManagerPriorityPolicy<T>, public soInstanceManagerAttributePolicy<T> {
+class soInstanceManagerFullProperty : public soInstanceManager<T> {
 public:
     virtual int add(T*, int);
 
@@ -105,3 +105,11 @@ public:
 
 };
 
+template <class T, u32 C>
+class soInstanceManagerFullPropertyVector: 
+    public soInstanceManagerFullProperty<T>,
+    public soInstanceManagerPriorityPolicy<T>,
+    public soInstanceManagerAttributePolicy<T> {
+        // Starts at 0x10, because there are 4 vtables.
+        soArrayVector<soInstanceUnitFullProperty<T>, C> m_arrayVector;
+};

--- a/Brawl/Include/so/so_module_accesser.h
+++ b/Brawl/Include/so/so_module_accesser.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <StaticAssert.h>
+#include <so/anim_cmd/so_anim_cmd_module_impl.h>
 #include <so/collision/so_collision_attack_module_impl.h>
 #include <so/collision/so_collision_hit_module_impl.h>
 #include <so/collision/so_collision_search_module_impl.h>
+#include <so/color_blend/so_color_blend_module_impl.h>
 #include <so/controller/so_controller_module_impl.h>
 #include <so/damage/so_damage_module_impl.h>
 #include <so/effect/so_effect_module_impl.h>
@@ -52,7 +54,7 @@ public:
     void* m_cameraModule;
     soWorkManageModule* m_workManageModule;
     void* m_debugModule;
-    void* m_animCmdModule;
+    soAnimCmdModule* m_animCmdModule;
     soStatusModule* m_statusModule;
     void* m_generalTermDisideModule;
     void* m_switchDecideModule;
@@ -68,7 +70,7 @@ public:
     void* m_slopeModule;
     void* m_shadowModule;
     void* m_itemManageModule;
-    void* m_colorBlendModule;
+    soColorBlendModule* m_colorBlendModule;
     void* m_jostleModule;
     void* m_abnormalModule;
     soSlowModule* m_slowModule;
@@ -148,6 +150,11 @@ public:
         return this->m_enumerationStart->m_workManageModule;
     }
 
+    inline soAnimCmdModule* getAnimCmdModule() 
+    {
+        return this->m_enumerationStart->m_animCmdModule;
+    }
+
     inline soStatusModule* getStatusModule()
     {
         return this->m_enumerationStart->m_statusModule;
@@ -171,6 +178,11 @@ public:
     inline soSlowModule* getSlowModule()
     {
         return this->m_enumerationStart->m_slowModule;
+    }
+
+    inline soColorBlendModule* getColorBlendModule()
+    {
+        return this->m_enumerationStart->m_colorBlendModule;
     }
 };
 static_assert(sizeof(soModuleAccesser) == 224, "Class is wrong size!");

--- a/Brawl/Include/so/status/so_status_event_observer.h
+++ b/Brawl/Include/so/status/so_status_event_observer.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <so/event/so_event_observer.h>
+
+class soStatusEventObserver : public soEventObserver<soStatusEventObserver> {
+public:
+    soStatusEventObserver(short unitID) : soEventObserver<soStatusEventObserver>(unitID) {};
+
+    virtual void addObserver(int param1, int param2);
+    virtual void notifyEventChangeStatus(int statusKind, int prevStatusKind, soStatusData* statusData, soModuleAccesser* moduleAccesser);
+};
+static_assert(sizeof(soStatusEventObserver) == 12, "Class is wrong size!");

--- a/Brawl/Include/so/work/so_work_manage_module_impl.h
+++ b/Brawl/Include/so/work/so_work_manage_module_impl.h
@@ -3,6 +3,7 @@
 #include <StaticAssert.h>
 #include <so/so_lock.h>
 #include <so/so_null.h>
+#include <so/anim_cmd/so_anim_cmd_event_observer.h>
 #include <so/work/so_general_work_simple.h>
 #include <so/event/so_event_observer.h>
 #include <types.h>

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -925,6 +925,11 @@ CC008000:WGPIPE
 27,1,0010E030:addObserver__41soEventObserver<22ftOutsideEventObserver>Fii
 27,5,26540:__vt__22ftOutsideEventObserver
 
+// soColorBlendModuleImpl
+27,1,000c0ef0:setSubColor__soColorBlendModuleImplFQ17GXColorUc
+27,1,000c0ee8:isEnableSubColor__soColorBlendModuleImplFv
+27,1,000c0ee0:getSubColor__soColorBlendModuleImplFv
+
 // ftEntryManager
 27,1,00119110:getEntity__14ftEntryManagerFUl
 

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -8,6 +8,7 @@
 27,6,58D8: g_stTriggerMng
 805a00e0:g_GameGlobal
 27,6,2E68: g_ftManager
+27,6,2E88: g_ftEntryManager
 27,6,2E90: g_ftSlotManager
 27,6,2EB4: g_ftInstanceManager
 27,6,2E70: g_ftAudienceManager
@@ -863,7 +864,13 @@ CC008000:WGPIPE
 27,1,0014d4b8:getWeight__23ftExternalValueAccesserFP7Fighter
 27,1,0014D19C:getHipPos__23ftExternalValueAccesserFP7Fighter
 
+// soAnimCmdEventObserver 
+27,5,00000358:__vt__22soAnimCmdEventObserver
+27,5,00000494:__vt__41soEventObserver<22soAnimCmdEventObserver>Fii
+27,1,000077B8:addObserver__41soEventObserver<22soAnimCmdEventObserver>Fii
+
 // soStatusEventObserver
+27,5,00000F98:__vt__21soStatusEventObserver
 27,1,000133C8:addObserver__21soStatusEventObserverFii
 27,1,00013628:notifyEventChangeStatus__21soStatusEventObserverFiiP12soStatusDataP16soModuleAccesser
 27,1,000136E4:addObserver__40soEventObserver<21soStatusEventObserver>Fii
@@ -1374,7 +1381,7 @@ CC008000:WGPIPE
 8006fe48:SetFixedWidth__Q22ms10CharWriterFf
 8006fc60:SetScale__Q22ms10CharWriterFff
 8006fc6c:SetScale__Q22ms10CharWriterFf
-8006fadc:SetAlpha__Q22ms10CharWriterFuc
+8006f988:SetAlpha__Q22ms10CharWriterFUc
 8006f944:SetColorMapping__Q22ms10CharWriterFQ34nw4r2ut5ColorQ34nw4r2ut5Color
 8006fadc:SetTextColor__Q22ms10CharWriterFQ34nw4r2ut5Color
 8006fe38:EnableFixedWidth__Q22ms10CharWriterFb


### PR DESCRIPTION
There's a few different things here:

- soColorBlendModule and mappings. Tested with my own code that uses them.
- soAnimCmdModule
     - This one is only partially finished, there are one or two classes that have weird layouts. Still, I was able to
        read a fighter's animCmd set with them, so I wanted to put it out as a starting point for future work and document
        what I found.
- Split related event observers into their own files as mentioned by code comments in the base observer header.
- Document some reverse engineering of fields and functions on ms::CharWriter.