### PR TITLE
Made m_hitStopFrame u32, Named soController m_buttonPrev

### DIFF
--- a/Brawl/Include/so/controller/so_controller_impl.h
+++ b/Brawl/Include/so/controller/so_controller_impl.h
@@ -96,7 +96,8 @@ public:
     float m_lr;
     char _60[8];
     int m_button;
-    char _72[8];
+    int m_buttonPrev;
+    char _76[4];
     int m_trigger;
     int m_release;
     soControllerTriggerData m_triggerData[2];

--- a/Brawl/Include/so/damage/so_damage.h
+++ b/Brawl/Include/so/damage/so_damage.h
@@ -38,7 +38,7 @@ struct soDamageLog {
     float m_angle;
     float m_lr;
     float m_frame;
-    float m_hitStopFrame;
+    u32 m_hitStopFrame;
     soCollisionAttackData::Attribute m_attribute;
     float m_damageAdd;
     int m_attackerTeamNo;


### PR DESCRIPTION
m_buttonPrev is a backup of m_button from the previous frame, and is used to calculate m_trigger and m_release on each frame. m_hitStopFrame is the number of frames of hitstop triggered by the corresponding damage event, but was incorrectly labelled a float.