### PR TITLE
Corrected IsEnableTermGroup Return Type

### DIFF
--- a/Brawl/Include/so/status/so_status_module_impl.h
+++ b/Brawl/Include/so/status/so_status_module_impl.h
@@ -53,9 +53,9 @@ public:
     virtual void startWatchChange();
     virtual bool isChanged();
     virtual bool checkTransition(soModuleAccesser* moduleAccesser);
-    virtual void enableTransitionTermGroup(int);
-    virtual void unableTransitionTermGroup(int);
-    virtual void isEnableTransitionTermGroup(int);
+    virtual void enableTransitionTermGroup(int groupID);
+    virtual void unableTransitionTermGroup(int groupID);
+    virtual bool isEnableTransitionTermGroup(int groupID);
     virtual void enableTransitionTermAll(int);
     virtual void clearTransitionTermAll(int);
     virtual void* getLastStatusTransitionInfo();
@@ -101,9 +101,9 @@ public:
     virtual void startWatchChange();
     virtual bool isChanged();
     virtual bool checkTransition(soModuleAccesser* moduleAccesser);
-    virtual void enableTransitionTermGroup(int);
-    virtual void unableTransitionTermGroup(int);
-    virtual void isEnableTransitionTermGroup(int);
+    virtual void enableTransitionTermGroup(int groupID);
+    virtual void unableTransitionTermGroup(int groupID);
+    virtual bool isEnableTransitionTermGroup(int groupID);
     virtual void enableTransitionTermAll(int);
     virtual void clearTransitionTermAll(int);
     virtual void* getLastStatusTransitionInfo();

--- a/Brawl/Include/so/transition/so_transition_module_impl.h
+++ b/Brawl/Include/so/transition/so_transition_module_impl.h
@@ -28,7 +28,7 @@ public:
 	virtual void unableTermAll(int groupID);
 	virtual void enableTermGroup(int groupID);
 	virtual void unableTermGroup(int groupID);
-	virtual u32 isEnableTermGroup(int groupID);
+	virtual bool isEnableTermGroup(int groupID);
 	virtual void addTerm(int groupID, int, int unitID, int, u16* option);
 	virtual void addGeneralTerm(int groupID, int unitID, soGeneralTerm* term);
 	virtual void addGeneralTermLastTerm(int groupID, soGeneralTerm* term);
@@ -52,7 +52,7 @@ public:
 	virtual void unableTermAll(int groupID);
 	virtual void enableTermGroup(int groupID);
 	virtual void unableTermGroup(int groupID);
-	virtual u32 isEnableTermGroup(int groupID);
+	virtual bool isEnableTermGroup(int groupID);
 	virtual void addTerm(int groupID, int, int unitID, int, u16* option);
 	virtual void addGeneralTerm(int groupID, int unitID, soGeneralTerm* term);
 	virtual void addGeneralTermLastTerm(int groupID, soGeneralTerm* term);


### PR DESCRIPTION
The ones in both soTransitionModule and soStatusModule actually return bool (with the Status Module one just being a wrapper for the soTransitionModule one); just fixes those to return correctly.