### PR TITLE
Labeled Some of the MuObjects in PlayerArea

### DIFF
--- a/Brawl/Include/mu/selchar/mu_selchar_player_area.h
+++ b/Brawl/Include/mu/selchar/mu_selchar_player_area.h
@@ -19,9 +19,19 @@ protected:
 public:
     u32 _0;
     muMenuController m_menuController;
-    char _0xAC[0x1C];
-    MuObject* m_muObject;
-    char _0xCC[0x84];
+    char _0xAC[0x4];
+    MuObject* m_muBackplate;
+    MuObject* m_muPlayerNum;
+    MuObject* m_muFranchiseIcon;
+    MuObject* m_muFrag;
+    MuObject* m_muCharPic;
+    MuObject* m_muUnk;
+    MuObject* m_muCharName;
+    MuObject* m_muTagBtn;
+    MuObject* m_muNameplate;
+    MuObject* m_muHandicap;
+    MuObject* m_muComputerLvl;
+    char _0xDC[0x74];
     void* m_objProcTask;
     muSelCharCBCalcWorld m_calcWorldCBs[7];
     muSelCharHand* m_selCharHand;

--- a/nw4r/include/nw4r/g3d/g3d_anmtexpat.h
+++ b/nw4r/include/nw4r/g3d/g3d_anmtexpat.h
@@ -55,7 +55,7 @@ namespace nw4r {
 
             char _spacer[40];
 
-            ResAnmTexPat m_anmTexPatFile;
+            ResAnmTexPat* m_anmTexPatFile;
 
             char _spacer2[4];
         };

--- a/nw4r/include/nw4r/g3d/g3d_anmtexpat.h
+++ b/nw4r/include/nw4r/g3d/g3d_anmtexpat.h
@@ -55,7 +55,7 @@ namespace nw4r {
 
             char _spacer[40];
 
-            ResAnmTexPat* m_anmTexPatFile;
+            ResAnmTexPat m_anmTexPatFile;
 
             char _spacer2[4];
         };


### PR DESCRIPTION
Also fixes a typo in the anmtexpat header, m_anmTexPatFile is indeed a pointer not a struct itself.