### PR TITLE
Sets Up Headers for Structures Used by the Transition System

### DIFF
--- a/Brawl/Include/so/so_instance_manager.h
+++ b/Brawl/Include/so/so_instance_manager.h
@@ -118,7 +118,6 @@ class soInstanceManagerFullPropertyVector:
 template <class T>
 class soInstanceManagerFullPropertyEccentric : public soInstanceManagerAttributePolicy<T>, public soInstanceManagerPriorityPolicy<T> {
 public:
-    typedef soArrayVector<soInstanceUnitFullProperty<T>, 1>* tdef_ArrayVec;
     // Starts at 0x8, because there are 2 vtables.
-    tdef_ArrayVec m_arrayVector;
+    soArray<soInstanceUnitFullProperty<T> >* m_array;
 };

--- a/Brawl/Include/so/so_instance_manager.h
+++ b/Brawl/Include/so/so_instance_manager.h
@@ -114,3 +114,11 @@ class soInstanceManagerFullPropertyVector:
         // Starts at 0x10, because there are 4 vtables.
         soArrayVector<soInstanceUnitFullProperty<T>, C> m_arrayVector;
 };
+
+template <class T>
+class soInstanceManagerFullPropertyEccentric : public soInstanceManagerAttributePolicy<T>, public soInstanceManagerPriorityPolicy<T> {
+public:
+    typedef soArrayVector<soInstanceUnitFullProperty<T>, 1>* tdef_ArrayVec;
+    // Starts at 0x8, because there are 2 vtables.
+    tdef_ArrayVec m_arrayVector;
+};

--- a/Brawl/Include/so/transition/so_transition_module_impl.h
+++ b/Brawl/Include/so/transition/so_transition_module_impl.h
@@ -23,10 +23,8 @@ static_assert(sizeof(soTransitionTerm) == 0x8, "Class is wrong size!");
 
 class soTransitionTermGroup {
 public:
-	typedef soInstanceManagerFullPropertyEccentric<soTransitionTerm> tdef_InstanceMgr;
-
 	u8 _unk00[4];
-	tdef_InstanceMgr m_transitionTermInstanceManager;
+	soInstanceManagerFullPropertyEccentric<soTransitionTerm> m_transitionTermInstanceManager;
 	u32 m_unitID;
 };
 static_assert(sizeof(soTransitionTermGroup) == 0x14, "Class is wrong size!");
@@ -59,8 +57,7 @@ public:
 
 class soTransitionModuleImpl : public soTransitionModule {
 public:
-	typedef soArrayVector<soTransitionTermGroup, 0x14>* tdef_GroupArray;
-	tdef_GroupArray m_transitionTermGroupArray;
+	soArray<soTransitionTermGroup>* m_transitionTermGroupArray;
 	int m_groupID;
 	soTransitionInfo m_transitionInfo;
 	virtual int checkEstablish(soModuleAccesser* accesser, int*, int groupID, u16*, int);

--- a/Brawl/Include/so/transition/so_transition_module_impl.h
+++ b/Brawl/Include/so/transition/so_transition_module_impl.h
@@ -12,6 +12,25 @@ public:
 };
 static_assert(sizeof(soTransitionInfo) == 0xC, "Class is wrong size!");
 
+class soTransitionTerm {
+public:
+	u8 _unk00[2];
+	u16 m_targetKind;
+	u16 m_generalTermIndex;
+	u8 _unk06[2];
+};
+static_assert(sizeof(soTransitionTerm) == 0x8, "Class is wrong size!");
+
+class soTransitionTermGroup {
+public:
+	typedef soInstanceManagerFullPropertyEccentric<soTransitionTerm> tdef_InstanceMgr;
+
+	u8 _unk00[4];
+	tdef_InstanceMgr m_transitionTermInstanceManager;
+	u32 m_unitID;
+};
+static_assert(sizeof(soTransitionTermGroup) == 0x14, "Class is wrong size!");
+
 class soGeneralTerm {
 public:
 	// soArrayConstractibleTable<T>, not literally a char array.
@@ -39,12 +58,11 @@ public:
 };
 
 class soTransitionModuleImpl : public soTransitionModule {
-private:
-	// soArrayVector<soTransitionTermGroup, C>, not literally a char array.
-	u8 m_transitionTermGroupArray[0x4];
+public:
+	typedef soArrayVector<soTransitionTermGroup, 0x14>* tdef_GroupArray;
+	tdef_GroupArray m_transitionTermGroupArray;
 	int m_groupID;
 	soTransitionInfo m_transitionInfo;
-public:
 	virtual int checkEstablish(soModuleAccesser* accesser, int*, int groupID, u16*, int);
 	virtual void enableTerm(int unitID, int groupID);
 	virtual void unableTerm(int unitID, int groupID);

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -26,6 +26,7 @@
 8059ff68:__float_nan
 8059ff6c:__float_huge
 8059ff70:__double_huge
+80B879AC:g_soGeneralTermManager
 
 
 // Hardware

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -26,6 +26,7 @@
 8059ff68:__float_nan
 8059ff6c:__float_huge
 8059ff70:__double_huge
+80B84F08:g_soGeneralTermCache
 80B879AC:g_soGeneralTermManager
 
 
@@ -514,6 +515,32 @@ CC008000:WGPIPE
 // soCollisionHitModule
 27,1,00042E4C:__dt__24soCollisionHitModuleImplFv
 27,1,00042AA4:__ct__24soCollisionHitModuleImplFP16soModuleAccesseriQ26gfTask8CategoryP29soArray<18soCollisionHitPart>P27soArray<16soCollisionGroup>P30soArray<19soCollisionHitGroup>P31soEventObserverRegistrationDescb
+
+// soTransitionTerm
+27,1,000775AC:checkEstablish__16soTransitionTermFP16soModuleAccesserPUlPv
+27,1,00077668:addGeneralTerm__16soTransitionTermFP13soGeneralTerm
+27,1,0007773C:clearGeneralTerm__16soTransitionTermFv
+
+// soTransitionTermGroup
+27,1,000AB2F4:checkEstablish__21soTransitionTermGroupFP16soModuleAccesserPUlPiPUlPUsPv
+27,1,000AB428:enableTerm__21soTransitionTermGroupFi
+27,1,000AB550:unableTerm__21soTransitionTermGroupFi
+27,1,000AB638:enableTermAll__21soTransitionTermGroupFv
+27,1,000AB6C8:unableTermAll__21soTransitionTermGroupFv
+27,1,000AB758:addTerm__21soTransitionTermGroupFiUlP16soTransitionTermPUs
+27,1,000ABBDC:addGeneralTerm__21soTransitionTermGroupFiP13soGeneralTerm
+27,1,000ABD14:addGeneralTermLastTerm__21soTransitionTermGroupFP13soGeneralTerm
+27,1,000ABE4C:clearTransitionTermAll__21soTransitionTermGroupFv
+
+// soGeneralTermManager
+27,1,0007B38C:clearAll__18soGeneralTermCacheFv
+27,1,0007B3AC:clearController__18soGeneralTermCacheFv
+27,1,0007B3C4:isFlag__18soGeneralTermCacheFUlPUc
+27,1,0007B418:setFlag__18soGeneralTermCacheFUlb
+27,1,0007B468:isButtonOn__18soGeneralTermCacheFUlPUc
+27,1,0007B4BC:setButtonOn__18soGeneralTermCacheFUlb
+27,1,0007B50C:isButtonTrigger__18soGeneralTermCacheFUlPUc
+27,1,0007B560:setButtonTrigger__18soGeneralTermCacheFUlb
 
 // Stage
 27,1,002225A8:createObj__5StageFv

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -26,9 +26,8 @@
 8059ff68:__float_nan
 8059ff6c:__float_huge
 8059ff70:__double_huge
-80B84F08:g_soGeneralTermCache
-80B879AC:g_soGeneralTermManager
-
+27,5,A6068:g_soGeneralTermCache
+27,5,A8B0C:g_soGeneralTermManager
 
 // Hardware
 CC008000:WGPIPE
@@ -532,7 +531,7 @@ CC008000:WGPIPE
 27,1,000ABD14:addGeneralTermLastTerm__21soTransitionTermGroupFP13soGeneralTerm
 27,1,000ABE4C:clearTransitionTermAll__21soTransitionTermGroupFv
 
-// soGeneralTermManager
+// soGeneralTermCache
 27,1,0007B38C:clearAll__18soGeneralTermCacheFv
 27,1,0007B3AC:clearController__18soGeneralTermCacheFv
 27,1,0007B3C4:isFlag__18soGeneralTermCacheFUlPUc


### PR DESCRIPTION
Specifically sets up soGeneralTerm, soGeneralTermCache, soTransitionTerm, and soTransitionTermGroup, along with some minor clean-up to previously unlabelled parameters on soTransitionModule functions.