### PR TITLE
soAnimCmdArgList Revamp

### DIFF
--- a/Brawl/Include/ac/ac_anim_cmd_impl.h
+++ b/Brawl/Include/ac/ac_anim_cmd_impl.h
@@ -4,6 +4,7 @@
 #include <so/so_array.h>
 #include <so/so_null.h>
 #include <types.h>
+#include <so/anim/so_anim_cmd_arg_list.h>
 
 // TODO: confirm class name
 struct acCmdArgConv {
@@ -67,19 +68,6 @@ struct acAnimCmdConv
     const acCmdArgConv* args;
 };
 
-// Currently, no real functions use this wrapper class.
-// TODO: Confirm that this is really acCmdArgList, and
-// use it in a legitimate way
-struct acCmdArgList {
-    soArrayContractibleTable<const acCmdArgConv> argList;
-
-    acCmdArgList() : argList() { }
-    acCmdArgList(const acCmdArgConv* p1, s32 p2) : argList(p1, p2) { }
-
-    ~acCmdArgList() { }
-    bool isEmpty() const { return argList.isEmpty(); }
-};
-
 class acAnimCmd : public soNullable {
 public:
     acAnimCmd() : soNullable(false) { }
@@ -89,7 +77,7 @@ public:
     virtual s8 getType() const = 0;
     virtual s32 getArgNum() const = 0;
     virtual u8 getOption() const = 0;
-    virtual soArrayContractibleTable<const acCmdArgConv> getArgList() = 0;
+    virtual soAnimCmdArgList getArgList() = 0;
     virtual bool getArg(acCmdArg* arg, s32 index) const = 0;
     virtual const acAnimCmdConv* getCmdAddress() const = 0;
     virtual bool isArgEmpty() const = 0;
@@ -106,7 +94,7 @@ public:
     virtual s8 getType() const;
     virtual s32 getArgNum() const;
     virtual u8 getOption() const;
-    virtual soArrayContractibleTable<const acCmdArgConv> getArgList();
+    virtual soAnimCmdArgList getArgList();
     virtual bool getArg(acCmdArg* arg, s32 index) const;
     virtual const acAnimCmdConv* getCmdAddress() const { return cmdAddr; }
     virtual bool isArgEmpty() const;
@@ -115,7 +103,7 @@ public:
 
     // TODO: made up deadstripped function to make soArrayFixed::isEmpty
     // get emitted earlier
-    acCmdArgList getEmptyArgList();
+    soArrayContractibleTable<const acCmdArgConv> getEmptyArgList();
 };
 static_assert(sizeof(acAnimCmdImpl) == 0xC, "Class is the wrong size!");
 
@@ -127,7 +115,7 @@ public:
     virtual s8 getType() const;
     virtual s32 getArgNum() const;
     virtual u8 getOption() const;
-    virtual soArrayContractibleTable<const acCmdArgConv> getArgList();
+    virtual soAnimCmdArgList getArgList();
     virtual bool getArg(acCmdArg* arg, s32 index) const;
     virtual const acAnimCmdConv* getCmdAddress() const;
     virtual bool isArgEmpty() const;

--- a/Brawl/Include/so/anim/so_anim_cmd_arg_list.h
+++ b/Brawl/Include/so/anim/so_anim_cmd_arg_list.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <StaticAssert.h>
+#include <types.h>
+#include <ac/ac_anim_cmd_impl.h>
+
+struct soModuleAccesser;
+struct acCmdArgConv;
+struct soAnimCmdArgList {
+    soArrayContractibleTable<const acCmdArgConv> m_argList;
+    // Is not populated by default, must be supplied before using functions for getting arguments.
+    soModuleAccesser* m_moduleAccesser;
+    // Is 0 by default. Is set to 1 if a getter function call fails, but is *not* set to 0 if it succeeds, so must be reset between calls.
+    u8 m_errorOnValueFetch;
+    // Doesn't appear to be used deliberately, though is sometimes zeroed by functions which zero m_errorOnValueFetch by stw'ing to it.
+    u8 _unk15[0x3];
+
+    soAnimCmdArgList() : m_argList() { }
+    soAnimCmdArgList(const acCmdArgConv* p1, s32 p2) : m_argList(p1, p2) { }
+
+    ~soAnimCmdArgList() { }
+
+    // Returns the variable ID of the specified argument. If the specified argument isn't a variable, m_errorOnValueFetch is set to 1!
+    u32 getValueIndex(u32 index);
+    // Returns the integer value of the specified argument. If the specified argument isn't a variable or Value/Integer typed, m_errorOnValueFetch is set to 1!
+    int getInt(u32 index);
+    // Returns the float value of the specified argument. If the specified argument isn't a variable or Scalar/Float typed, m_errorOnValueFetch is set to 1!
+    double getFloat(u32 index);
+    // Returns the boolean value of the specified argument. If the specified argument isn't Boolean typed, m_errorOnValueFetch is set to 1!
+    bool getBool(u32 index);
+
+    bool isEmpty() const { return m_argList.isEmpty(); }
+};
+static_assert(sizeof(soAnimCmdArgList) == 0x18, "Class is the wrong size!");

--- a/RSBE01.lst
+++ b/RSBE01.lst
@@ -691,6 +691,11 @@ CC008000:WGPIPE
 27,1,0025ee6c:set__18soArrayList<Ul,32>FlRCUll
 27,1,0025ef44:isNull__18soArrayList<Ul,32>CFv
 
+27,1,000735C8:getInt__16soAnimCmdArgListFUl
+27,1,000736B8:getFloat__16soAnimCmdArgListFUl
+27,1,000737DC:getBool__16soAnimCmdArgListFUl
+27,1,0007388C:getValueIndex__16soAnimCmdArgListFUl
+
 // soEventSystem
 27,1,0008F064:getInstance__13soEventSystemFv
 27,1,0008F1BC:getManager__13soEventSystemFl


### PR DESCRIPTION
Added the remaining data members and member functions, and moved into its own file (as indicated by its functions being defined in "so_anim_cmd_arg_list.o" according to Ghidra).